### PR TITLE
Update qname regex in Decoder.pm

### DIFF
--- a/lib/RDF/aREF/Decoder.pm
+++ b/lib/RDF/aREF/Decoder.pm
@@ -15,8 +15,8 @@ our @EXPORT_OK = qw(prefix localName qName blankNode blankNodeIdentifier
 
 our ($PREFIX, $NAME);
 BEGIN {
-    my $nameChar = 'A-Z_a-z\N{U+00C0}-\N{U+00D6}\N{U+00D8}-\N{U+00F6}\N{U+00F8}-\N{U+02FF}\N{U+0370}-\N{U+037D}\N{U+037F}-\N{U+1FFF}\N{U+200C}-\N{U+200D}\N{U+2070}-\N{U+218F}\N{U+2C00}-\N{U+2FEF}\N{U+3001}-\N{U+D7FF}\N{U+F900}-\N{U+FDCF}\N{U+FDF0}-\N{U+FFFD}\N{U+10000}-\N{U+EFFFF}';
-    my $nameStartChar = $nameChar.'0-9\N{U+00B7}\N{U+0300}\N{U+036F}\N{U+203F}-\N{U+2040}-';
+    my $nameStartChar = 'A-Z_a-z\N{U+00C0}-\N{U+00D6}\N{U+00D8}-\N{U+00F6}\N{U+00F8}-\N{U+02FF}\N{U+0370}-\N{U+037D}\N{U+037F}-\N{U+1FFF}\N{U+200C}-\N{U+200D}\N{U+2070}-\N{U+218F}\N{U+2C00}-\N{U+2FEF}\N{U+3001}-\N{U+D7FF}\N{U+F900}-\N{U+FDCF}\N{U+FDF0}-\N{U+FFFD}\N{U+10000}-\N{U+EFFFF}';
+    my $nameChar = $nameStartChar.'0-9\-\.\N{U+00B7}\N{U+0300}-\N{U+036F}\N{U+203F}-\N{U+2040}';
     our $PREFIX = '[a-z][a-z0-9]*';
     our $NAME   = "[$nameStartChar][$nameChar]*";
 }

--- a/t/encoder.t
+++ b/t/encoder.t
@@ -65,7 +65,11 @@ test_encoder $encoder => 'object',
     {
         type => 'uri',
         value => 'http://www.w3.org/2006/vcard/ns#street-address',
-    } => '<http://www.w3.org/2006/vcard/ns#street-address>',
+    } => 'vcard_street-address',
+    {
+        type => 'uri',
+        value => 'http://undefinednamespace.foo/thing'
+    } => '<http://undefinednamespace.foo/thing>',
     {
         type  => 'literal',
         value => 'hello, world!',
@@ -113,7 +117,8 @@ test_encoder $encoder => 'bnode',
 test_encoder $encoder => 'qname',
     'http://www.w3.org/1999/02/22-rdf-syntax-ns#type' => 'rdf_type',
     'http://schema.org/Review' => 'schema_Review',
-    'http://www.w3.org/2006/vcard/ns#street-address' => undef,
+    'http://www.w3.org/2006/vcard/ns#street-address' => 'vcard_street-address',
+    'http://undefinednamespace.foo/thing' => undef
 ;
 
 # encoder methods with ns => 0


### PR DESCRIPTION
This PR corrects an apparent reversal of regexps for nameStartChar and nameChar in RDF::aREF::Decoder.

The previous implementation appears to be broken, as it (for example) doesn't allow for numbers to appear in the name part of a qName (e.g. `bflc_name00MatchKey`). According to the [W3C](https://www.w3.org/TR/REC-xml/#NT-Name), names are formally defined as:

```
NameStartChar      ::=          ":" | [A-Z] | "_" | [a-z] | [#xC0-#xD6] | [#xD8-#xF6] | [#xF8-#x2FF] | [#x370-#x37D] | [#x37F-#x1FFF] | [#x200C-#x200D] | [#x2070-#x218F] | [#x2C00-#x2FEF] | [#x3001-#xD7FF] | [#xF900-#xFDCF] | [#xFDF0-#xFFFD] | [#x10000-#xEFFFF]
NameChar           ::=          NameStartChar | "-" | "." | [0-9] | #xB7 | [#x0300-#x036F] | [#x203F-#x2040]
Name       ::=          NameStartChar (NameChar)*
```

The previous implementation in RDF::aREF::Decoder had the definitions of NameStartChar and NameChar reversed. This change also required an update to the encoder tests, which enshrined the behavior of not allowing the hyphen character in the name part of the qName.

In addition, this PR includes a commit that corrects a test that was failing due to a differing resolution of the `geo` prefix. I'm not sure why the prefix is resolved differently from when the test was written, unless there is a bug in RDF::NS (definitely outside the scope of this issue).

Feel free to do what needs to be done to make this change better, or let me know if I'm way off base. Thanks!

